### PR TITLE
feat: add mobile app backend API and push support

### DIFF
--- a/migrations/0001_push_tokens.sql
+++ b/migrations/0001_push_tokens.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS push_tokens (
+  user_id INTEGER NOT NULL,
+  token TEXT NOT NULL,
+  platform TEXT,
+  created_at TEXT DEFAULT (datetime('now')),
+  PRIMARY KEY (user_id, token)
+);
+
+CREATE INDEX IF NOT EXISTS idx_push_tokens_user_id ON push_tokens(user_id);

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "db:schema": "wrangler d1 execute anivault --file=./d1_schema.sql",
     "db:data": "wrangler d1 execute anivault --file=./d1_data.sql",
     "db:sessions": "wrangler d1 execute anivault --file=./d1_sessions.sql",
+    "db:push-tokens": "wrangler d1 execute anivault --file=./migrations/0001_push_tokens.sql",
     "discord:pc": "node tools/discord-rpc-bridge.mjs"
   },
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import { Hono } from 'hono';
 import { authRoutes } from './routes/auth';
+import { mobileAuthRoutes } from './routes/api-mobile-auth';
+import { mobileContentRoutes } from './routes/api-mobile-content';
 import { homeRoutes } from './routes/home';
 import { browseRoutes } from './routes/browse';
 import { discoverRoutes } from './routes/discover';
@@ -45,9 +47,7 @@ import { legacyRedirectRoutes } from './routes/legacy-redirects';
 import { apiChatRoutes } from './routes/api-chat';
 import { healthRoutes } from './routes/health';
 import { handleScheduled } from './scheduled';
-import { discordPresenceWebScript } from './render/discord-presence-web';
 
-// Env bindings + secrets (set secrets via `wrangler secret put NAME`, see wrangler.toml)
 export interface Env {
   DB: D1Database;
   API_CACHE: KVNamespace;
@@ -55,6 +55,7 @@ export interface Env {
   SITE_NAME: string;
   SITE_URL: string;
   SESSION_LIFETIME_SECONDS: string;
+  MOBILE_SESSION_LIFETIME_SECONDS?: string;
   API_CACHE_ENABLED?: string;
   API_CACHE_TIME?: string;
   GOOGLE_CLIENT_ID?: string;
@@ -66,10 +67,6 @@ export interface Env {
   DISCORD_SERVER_ID?: string;
   DISCORD_BOT_TOKEN?: string;
   DISCORD_LOG_CHANNEL_ID?: string;
-  // Shared secret between this Worker and the AniVault Discord bot (Vercel).
-  // Used both ways: the bot doesn't call in with it anymore for notifications
-  // (the Worker posts those to Discord directly), but the bot DOES send it
-  // as `x-bot-secret` when hitting /api/discord/user-lookup for /user.
   BOT_SECRET?: string;
   MAL_CLIENT_ID?: string;
   MAL_CLIENT_SECRET?: string;
@@ -85,40 +82,13 @@ const app = new Hono<{ Bindings: Env }>();
 
 app.route('/', healthRoutes);
 app.route('/', authRoutes);
+app.route('/', mobileAuthRoutes);
+app.route('/', mobileContentRoutes);
 app.route('/', homeRoutes);
 app.route('/', browseRoutes);
 app.route('/', discoverRoutes);
 app.route('/', animeRoutes);
 app.route('/', characterRoutes);
-
-// The browser cannot open Discord's Windows IPC pipe directly. On normal
-// AniVault web pages we therefore inject a tiny, optional bridge client that
-// talks to the user's localhost helper. It is completely silent when the
-// helper is not installed/running, so this does not affect ordinary visitors.
-app.use('/watch', async (c, next) => {
-  await next();
-
-  if (c.req.method !== 'GET') return;
-  const contentType = c.res.headers.get('content-type') ?? '';
-  if (!contentType.includes('text/html')) return;
-
-  const html = await c.res.text();
-  if (html.includes('__anivaultPcDiscordPresence')) return;
-
-  const script = discordPresenceWebScript();
-  const injected = html.includes('</body>')
-    ? html.replace('</body>', `${script}</body>`)
-    : html + script;
-
-  const headers = new Headers(c.res.headers);
-  headers.delete('content-length');
-  c.res = new Response(injected, {
-    status: c.res.status,
-    statusText: c.res.statusText,
-    headers,
-  });
-});
-
 app.route('/', watchRoutes);
 app.route('/', listRoutes);
 app.route('/', apiListRoutes);
@@ -158,11 +128,6 @@ app.route('/', watchNowRoutes);
 app.route('/', legacyRedirectRoutes);
 app.route('/', apiChatRoutes);
 
-// Global error handler — without this, an unhandled exception anywhere just
-// shows a bare "Internal Server Error" with no detail in the logs beyond
-// whatever single stack frame Cloudflare happens to capture. This logs the
-// full error (message + stack + which URL triggered it) and returns a
-// plain but on-brand error page instead of a blank one.
 app.onError((err, c) => {
   console.error(`[unhandled] ${c.req.method} ${c.req.url} — ${err.message}\n${err.stack ?? ''}`);
   return c.html(
@@ -176,7 +141,6 @@ app.onError((err, c) => {
 
 export default {
   fetch: app.fetch,
-  // Cloudflare Cron Trigger entry point — see [triggers] in wrangler.toml.
   async scheduled(event: ScheduledController, env: Env, ctx: ExecutionContext) {
     ctx.waitUntil(handleScheduled(env, event.cron));
   },

--- a/src/lib/notification.ts
+++ b/src/lib/notification.ts
@@ -1,6 +1,7 @@
 // Full port of includes/notification.php.
 import { Db } from './db';
 import { h } from './helpers';
+import { sendPushToUser, sendPush } from './push';
 
 export interface NotificationRow {
   [key: string]: unknown;
@@ -27,8 +28,6 @@ export const NOTIFICATION_TYPES: Record<string, { icon: string; color: string; l
 };
 
 export const Notification = {
-  /** Creates a notification, skipping self-notifications (except announcements)
-   * and de-duping identical (user, actor, type, entity) notifications within 1 hour. */
   async create(db: Db, userId: number, actorId: number, type: string, entityId: number | null = null, entityMeta: string | null = null): Promise<void> {
     if (userId === actorId && type !== 'announcement') return;
 
@@ -44,10 +43,15 @@ export const Notification = {
       'INSERT INTO notifications (user_id, actor_id, type, entity_id, entity_meta) VALUES (?,?,?,?,?)',
       [userId, actorId, type, entityId, entityMeta]
     );
+
+    const meta = NOTIFICATION_TYPES[type];
+    if (meta) {
+      const actor = await db.fetchOne<{ username: string }>('SELECT username FROM users WHERE id = ?', [actorId]);
+      const actorName = actor?.username ?? 'Someone';
+      await sendPushToUser(db, userId, 'AniVault', `${actorName} ${meta.label}`, { type, entityId });
+    }
   },
 
-  /** Broadcasts an announcement notification to every user, skipping users
-   * who already have one for this announcement (idempotent, safe to re-run). */
   async broadcast(db: Db, announcementId: number, actorId: number, title: string): Promise<void> {
     const users = await db.fetchAll<{ id: number }>('SELECT id FROM users', []);
     for (const user of users) {
@@ -60,6 +64,12 @@ export const Notification = {
         'INSERT INTO notifications (user_id, actor_id, type, entity_id, entity_meta) VALUES (?,?,?,?,?)',
         [user.id, actorId, 'announcement', announcementId, title]
       );
+    }
+    try {
+      const allTokens = await db.fetchAll<{ token: string }>('SELECT token FROM push_tokens', []);
+      await sendPush(allTokens.map((t) => t.token), 'AniVault', title, { type: 'announcement', entityId: announcementId });
+    } catch {
+      // push_tokens may not be migrated yet — announcements still save fine.
     }
   },
 

--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -1,0 +1,39 @@
+// Sends push notifications via Expo's push service to any registered
+// devices for a user. Called from notification.ts right after a
+// notification row is inserted, so app users get a push the same moment a
+// web user would see the bell update — same events, same data, just a
+// different delivery channel.
+import { Db } from './db';
+
+const EXPO_PUSH_URL = 'https://exp.host/--/api/v2/push/send';
+
+export async function getPushTokensForUser(db: Db, userId: number): Promise<string[]> {
+  try {
+    const rows = await db.fetchAll<{ token: string }>('SELECT token FROM push_tokens WHERE user_id = ?', [userId]);
+    return rows.map((r) => r.token);
+  } catch {
+    return [];
+  }
+}
+
+export async function sendPush(tokens: string[], title: string, body: string, data?: Record<string, unknown>): Promise<void> {
+  if (tokens.length === 0) return;
+  try {
+    const messages = tokens.map((to) => ({ to, title, body, data, sound: 'default' }));
+    for (let i = 0; i < messages.length; i += 100) {
+      const chunk = messages.slice(i, i + 100);
+      await fetch(EXPO_PUSH_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify(chunk),
+      });
+    }
+  } catch {
+    // Best-effort — push failures must never break notification creation.
+  }
+}
+
+export async function sendPushToUser(db: Db, userId: number, title: string, body: string, data?: Record<string, unknown>): Promise<void> {
+  const tokens = await getPushTokensForUser(db, userId);
+  await sendPush(tokens, title, body, data);
+}

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -37,26 +37,53 @@ export class Session {
     this.isNew = isNew;
   }
 
+  private fromBearer = false;
+
+  private static bearerId(c: Context): string | null {
+    const header = c.req.header('authorization') ?? c.req.header('Authorization');
+    if (!header) return null;
+    const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+    return match ? match[1].trim() : null;
+  }
+
   static async load(c: Context, db: Db, lifetimeSeconds: number): Promise<Session> {
     const cookieId = getCookie(c, COOKIE_NAME);
-    if (cookieId) {
+    const bearerId = cookieId ? null : Session.bearerId(c);
+    const id = cookieId ?? bearerId;
+
+    if (id) {
       const row = await db.fetchOne<{ id: string; user_id: number | null; data: string; expires_at: number }>(
         'SELECT id, user_id, data, expires_at FROM sessions WHERE id = ?',
-        [cookieId]
+        [id]
       );
       if (row && row.expires_at > Math.floor(Date.now() / 1000)) {
         let parsed: SessionData = {};
         try { parsed = JSON.parse(row.data || '{}'); } catch { /* ignore malformed */ }
-        return new Session(db, row.id, row.user_id, parsed, false);
+        const session = new Session(db, row.id, row.user_id, parsed, false);
+        session.fromBearer = !!bearerId;
+        return session;
       }
     }
-    // No valid session -> create a fresh one
-    const id = crypto.randomUUID();
-    return new Session(db, id, null, {}, true);
+    const newId = crypto.randomUUID();
+    const session = new Session(db, newId, null, {}, true);
+    session.fromBearer = cookieId === undefined && bearerId !== null;
+    return session;
   }
 
-  /** Persists session state to D1 and writes the cookie. Call once per request, at the end. */
   async save(c: Context, lifetimeSeconds: number): Promise<void> {
+    await this.persist(lifetimeSeconds);
+    if (!this.fromBearer) {
+      setCookie(c, COOKIE_NAME, this.id, {
+        path: '/',
+        httpOnly: true,
+        secure: true,
+        sameSite: 'Lax',
+        maxAge: lifetimeSeconds,
+      });
+    }
+  }
+
+  async persist(lifetimeSeconds: number): Promise<void> {
     const now = Math.floor(Date.now() / 1000);
     const expiresAt = now + lifetimeSeconds;
     const json = JSON.stringify(this.data);
@@ -66,20 +93,13 @@ export class Session {
         'INSERT INTO sessions (id, user_id, data, expires_at, created_at) VALUES (?, ?, ?, ?, ?)',
         [this.id, this.user_id, json, expiresAt, now]
       );
+      this.isNew = false;
     } else {
       await this.db.query(
         'UPDATE sessions SET user_id = ?, data = ?, expires_at = ? WHERE id = ?',
         [this.user_id, json, expiresAt, this.id]
       );
     }
-
-    setCookie(c, COOKIE_NAME, this.id, {
-      path: '/',
-      httpOnly: true,
-      secure: true,
-      sameSite: 'Lax',
-      maxAge: lifetimeSeconds,
-    });
   }
 
   async destroy(c: Context): Promise<void> {

--- a/src/routes/api-mobile-auth.ts
+++ b/src/routes/api-mobile-auth.ts
@@ -1,0 +1,128 @@
+// Mobile app auth. Deliberately thin: all the real logic (password checks,
+// bcrypt, auto-registration, OAuth) already lives in lib/auth.ts and is
+// shared with the website's /api/auth_ajax.php. The only thing that differs
+// for the app is the transport — no cookie jar, so the session id (our
+// existing D1-backed session token) goes back as JSON instead, and the app
+// sends it as `Authorization: Bearer <token>` on every request after that.
+import { Hono } from 'hono';
+import { Db } from '../lib/db';
+import { Session } from '../lib/session';
+import { Auth } from '../lib/auth';
+import type { Env } from '../index';
+
+export const mobileAuthRoutes = new Hono<{ Bindings: Env }>();
+
+function clientIp(c: any): string { return c.req.header('cf-connecting-ip') ?? 'unknown'; }
+function lifetime(c: any): number { return Number(c.env.MOBILE_SESSION_LIFETIME_SECONDS ?? 60 * 60 * 24 * 30); }
+async function currentUser(db: Db, userId: number) {
+  return db.fetchOne('SELECT id, uid, username, email, avatar_url, bio, role FROM users WHERE id = ?', [userId]);
+}
+
+mobileAuthRoutes.post('/api/mobile/login', async (c) => {
+  const db = new Db(c.env.DB); const session = await Session.load(c, db, lifetime(c));
+  const auth = new Auth(db, session, c.env as any, clientIp(c));
+  const body = await c.req.json().catch(() => ({}));
+  const username = String(body.username ?? '').trim(); const password = String(body.password ?? '');
+  if (!username || !password) return c.json({ success: false, message: 'Username and password are required.' }, 400);
+  const result = await auth.login(username, password);
+  if (!result.success) return c.json(result, 401);
+  await session.persist(lifetime(c));
+  const user = await currentUser(db, session.user_id!);
+  return c.json({ success: true, token: session.id, expiresIn: lifetime(c), user });
+});
+
+mobileAuthRoutes.post('/api/mobile/register', async (c) => {
+  const db = new Db(c.env.DB); const session = await Session.load(c, db, lifetime(c));
+  const auth = new Auth(db, session, c.env as any, clientIp(c));
+  const body = await c.req.json().catch(() => ({}));
+  const username = String(body.username ?? '').trim(); const email = String(body.email ?? '').trim(); const password = String(body.password ?? '');
+  const result = await auth.register(username, email, password);
+  if (!result.success) return c.json(result, 400);
+  await session.persist(lifetime(c));
+  const user = await currentUser(db, session.user_id!);
+  return c.json({ success: true, token: session.id, expiresIn: lifetime(c), user });
+});
+
+mobileAuthRoutes.get('/api/mobile/me', async (c) => {
+  const db = new Db(c.env.DB); const session = await Session.load(c, db, lifetime(c));
+  const auth = new Auth(db, session, c.env as any, clientIp(c));
+  if (!auth.check()) return c.json({ success: false, message: 'Not logged in.' }, 401);
+  const user = await currentUser(db, session.user_id!);
+  return c.json({ success: true, user });
+});
+
+mobileAuthRoutes.post('/api/mobile/logout', async (c) => {
+  const db = new Db(c.env.DB); const session = await Session.load(c, db, lifetime(c));
+  await db.query('DELETE FROM sessions WHERE id = ?', [session.id]);
+  return c.json({ success: true });
+});
+
+mobileAuthRoutes.get('/mobile-handoff', async (c) => {
+  const db = new Db(c.env.DB); const token = c.req.query('token') ?? ''; const redirect = c.req.query('redirect') ?? '/'; const siteUrl = c.env.SITE_URL;
+  if (!token) return c.redirect(siteUrl + '/login');
+  const row = await db.fetchOne<{ id: string; expires_at: number }>('SELECT id, expires_at FROM sessions WHERE id = ?', [token]);
+  if (!row || row.expires_at <= Math.floor(Date.now() / 1000)) return c.redirect(siteUrl + '/login');
+  const { setCookie } = await import('hono/cookie');
+  setCookie(c, 'av_session', row.id, { path: '/', httpOnly: true, secure: true, sameSite: 'Lax', maxAge: row.expires_at - Math.floor(Date.now() / 1000) });
+  return c.redirect(`${siteUrl}${redirect}`);
+});
+
+mobileAuthRoutes.post('/api/mobile/push-token', async (c) => {
+  const db = new Db(c.env.DB); const session = await Session.load(c, db, lifetime(c));
+  const auth = new Auth(db, session, c.env as any, clientIp(c));
+  if (!auth.check()) return c.json({ success: false, message: 'Not logged in.' }, 401);
+  const body = await c.req.json().catch(() => ({})); const token = String(body.token ?? '').trim(); const platform = String(body.platform ?? '').trim();
+  if (!token) return c.json({ success: false, message: 'Token is required.' }, 400);
+  try {
+    await db.query('INSERT INTO push_tokens (user_id, token, platform) VALUES (?, ?, ?) ON CONFLICT(user_id, token) DO UPDATE SET platform = excluded.platform', [session.user_id, token, platform]);
+    return c.json({ success: true });
+  } catch {
+    return c.json({ success: false, message: 'push_tokens table not migrated yet.' }, 500);
+  }
+});
+
+mobileAuthRoutes.delete('/api/mobile/push-token', async (c) => {
+  const db = new Db(c.env.DB); const session = await Session.load(c, db, lifetime(c));
+  const body = await c.req.json().catch(() => ({})); const token = String(body.token ?? '').trim();
+  if (token) await db.query('DELETE FROM push_tokens WHERE token = ?', [token]).catch(() => {});
+  return c.json({ success: true });
+});
+
+mobileAuthRoutes.post('/api/mobile/settings', async (c) => {
+  const db = new Db(c.env.DB); const session = await Session.load(c, db, lifetime(c)); const auth = new Auth(db, session, c.env as any, clientIp(c));
+  if (!auth.check()) return c.json({ success: false, message: 'Not logged in.' }, 401);
+  const body = await c.req.json().catch(() => ({})); const data: { bio?: string; new_password?: string } = {};
+  if (typeof body.bio === 'string') data.bio = body.bio;
+  if (typeof body.new_password === 'string' && body.new_password) data.new_password = body.new_password;
+  return c.json(await auth.updateProfile(session.user_id!, data));
+});
+
+mobileAuthRoutes.get('/api/mobile/list-sync/status', async (c) => {
+  const db = new Db(c.env.DB); const session = await Session.load(c, db, lifetime(c)); const auth = new Auth(db, session, c.env as any, clientIp(c));
+  if (!auth.check()) return c.json({ success: false, message: 'Not logged in.' }, 401);
+  const row = await db.fetchOne<any>('SELECT mal_sync_username, mal_sync_access_token, anilist_sync_username, anilist_sync_access_token FROM users WHERE id = ?', [session.user_id]);
+  return c.json({ success: true, mal: { connected: !!row?.mal_sync_access_token, username: row?.mal_sync_username ?? null }, anilist: { connected: !!row?.anilist_sync_access_token, username: row?.anilist_sync_username ?? null } });
+});
+
+mobileAuthRoutes.post('/api/mobile/list-sync/action', async (c) => {
+  const db = new Db(c.env.DB); const session = await Session.load(c, db, lifetime(c)); const auth = new Auth(db, session, c.env as any, clientIp(c));
+  if (!auth.check()) return c.json({ success: false, message: 'Not logged in.' }, 401);
+  const body = await c.req.json().catch(() => ({})); const action = String(body.action ?? ''); const userId = session.user_id!;
+  const { MalSync, AniListSync } = await import('../lib/list-sync');
+  switch (action) {
+    case 'mal_sync_now': { const r = await MalSync.pullMerge(c.env as any, db, userId); return c.json(r.error ? { success: false, message: r.error } : { success: true, message: r.added ? `Imported ${r.added} new anime from MAL.` : 'Already up to date.' }); }
+    case 'mal_disconnect': await MalSync.disconnect(db, userId); return c.json({ success: true, message: 'Disconnected from MyAnimeList.' });
+    case 'anilist_sync_now': return c.json(await AniListSync.requestPull(db, userId));
+    case 'anilist_disconnect': await AniListSync.disconnect(db, userId); return c.json({ success: true, message: 'Disconnected from AniList.' });
+    default: return c.json({ success: false, message: 'Unknown action.' }, 400);
+  }
+});
+
+mobileAuthRoutes.get('/api/mobile/oauth-start', async (c) => {
+  const db = new Db(c.env.DB); const session = await Session.load(c, db, lifetime(c)); const auth = new Auth(db, session, c.env as any, clientIp(c));
+  const provider = c.req.query('provider'); session.data.oauth_redirect = 'anivault://oauth-callback';
+  const url = provider === 'discord' ? auth.getDiscordAuthUrl() : provider === 'google' ? auth.getGoogleAuthUrl() : null;
+  await session.save(c, lifetime(c)); if (!url) return c.text('Unknown provider.', 400); return c.redirect(url);
+});
+
+export { mobileAuthRoutes as default };

--- a/src/routes/api-mobile-content.ts
+++ b/src/routes/api-mobile-content.ts
@@ -1,0 +1,100 @@
+import { Hono } from 'hono';
+import type { Env } from '../index';
+import { Db } from '../lib/db';
+import { Session } from '../lib/session';
+import { Auth } from '../lib/auth';
+import { MalAPI } from '../lib/mal-api';
+import { buildCardMetaMap } from '../lib/anime-card';
+import { getUserAnimeStatuses } from '../lib/user-list';
+import { DubStatus } from '../lib/dub-status';
+import { EpisodeAir } from '../lib/episode-air';
+
+export const mobileContentRoutes = new Hono<{ Bindings: Env }>();
+
+async function buildCtx(c: any) {
+  const db = new Db(c.env.DB); const lifetime = Number(c.env.SESSION_LIFETIME_SECONDS ?? 86400);
+  const session = await Session.load(c, db, lifetime);
+  const auth = new Auth(db, session, c.env as any, c.req.header('cf-connecting-ip') ?? 'unknown');
+  const mal = new MalAPI(c.env as any, c.env.API_CACHE, db); return { db, session, auth, mal };
+}
+
+mobileContentRoutes.get('/api/mobile/browse', async (c) => {
+  const { db, auth, mal } = await buildCtx(c); const q = (c.req.query('q') ?? '').trim(); const status = c.req.query('status') ?? ''; const type = c.req.query('type') ?? '';
+  const page = Math.max(1, parseInt(c.req.query('page') ?? '1', 10) || 1);
+  const genres = c.req.queries('genres[]')?.map((g) => parseInt(g, 10)).filter((n) => !Number.isNaN(n)) ?? [];
+  let result: { data: any[]; pagination: any };
+  if (q) result = await mal.searchAnime(q, page, type, status); else if (genres.length > 0) result = await mal.getAnimeByGenres(genres, page); else result = await mal.getTopAnime('bypopularity', page);
+  const items = result.data ?? []; const cardMeta = await buildCardMetaMap(db, items); const currentUser = auth.check() ? await auth.getCurrentUser() : null; const userStatuses = currentUser ? await getUserAnimeStatuses(db, currentUser.id) : {};
+  const data = items.map((a: any) => ({ id: a.mal_id, title: a.title_english && a.title_english !== a.title ? a.title_english : a.title, image: a.images?.jpg?.large_image_url ?? a.images?.jpg?.image_url ?? '', score: a.score ?? null, type: a.type ?? '', episodes: a.episodes ?? 0, airedInfo: cardMeta.get(a.mal_id)?.airedInfo ?? null, dubbedLangs: cardMeta.get(a.mal_id)?.dubbedLangs ?? [], userStatus: userStatuses[a.mal_id] ?? null }));
+  return c.json({ data, pagination: result.pagination ?? {}, genres: mal.getAnimeGenres().data });
+});
+
+mobileContentRoutes.get('/api/mobile/anime/:id', async (c) => {
+  const { db, auth, mal } = await buildCtx(c); const id = parseInt(c.req.param('id'), 10) || 0; if (!id) return c.json({ success: false, message: 'Invalid anime id.' }, 400);
+  const result = await mal.getAnime(id); const anime = result.data; if (!anime) return c.json({ success: false, message: 'Anime not found.' }, 404);
+  const isAiring = anime.status === 'Currently Airing'; let airedInfo = null; if (isAiring) ({ info: airedInfo } = await EpisodeAir.getCachedAny(db, id));
+  const totalEps = isAiring ? (airedInfo?.total ?? anime.episodes ?? 0) : (anime.episodes ?? 0); const airedSoFar = isAiring ? (airedInfo?.aired ?? null) : null; const dubbedLangs = (await DubStatus.getForMany(db, [id])).get(id) ?? [];
+  const currentUser = auth.check() ? await auth.getCurrentUser() : null; let userEntry = null; let isFavorite = false;
+  if (currentUser) { const { AnimeTracker } = await import('../lib/tracker'); userEntry = await AnimeTracker.getUserEntry(db, currentUser.id, id); isFavorite = await AnimeTracker.isFavorite(db, currentUser.id, id); }
+  const seriesEntries = (anime.related_anime ?? []).filter((rel: any) => rel).map((rel: any) => ({ id: rel?.entry?.mal_id ?? 0, title: rel?.entry?.title ?? '', type: rel?.relation_type_formatted ?? '' }));
+  return c.json({ success: true, anime: { id: anime.mal_id, title: anime.title_english && anime.title_english !== anime.title ? anime.title_english : anime.title, titleJapanese: anime.title_japanese ?? null, image: anime.images?.jpg?.large_image_url ?? '', synopsis: anime.synopsis ?? '', score: anime.score ?? null, status: anime.status ?? '', type: anime.type ?? '', genres: (anime.genres ?? []).map((g: any) => ({ id: g.mal_id, name: g.name })), totalEpisodes: totalEps, airedSoFar, isAiring, dubbedLangs, related: seriesEntries }, userEntry, isFavorite });
+});
+
+mobileContentRoutes.get('/api/mobile/anime/:id/episodes', async (c) => {
+  const { mal } = await buildCtx(c); const id = parseInt(c.req.param('id'), 10) || 0; const page = Math.max(1, parseInt(c.req.query('page') ?? '1', 10) || 1); if (!id) return c.json({ success: false, message: 'Invalid anime id.' }, 400);
+  const result = await mal.getAnimeEpisodes(id, page); return c.json({ success: true, data: result.data ?? [], pagination: result.pagination ?? {} });
+});
+
+mobileContentRoutes.get('/api/mobile/profile', async (c) => {
+  const { db, auth, session } = await buildCtx(c); if (!auth.check()) return c.json({ success: false, message: 'Not logged in.' }, 401); const userId = session.user_id!; const user = await auth.getCurrentUser(); if (!user) return c.json({ success: false, message: 'User not found.' }, 404);
+  const { Badge } = await import('../lib/badges'); const { AnimeTracker } = await import('../lib/tracker'); const { Follow } = await import('../lib/follow');
+  const [badges, stats, favorites, followerCount, followingCount] = await Promise.all([Badge.getForUser(db, userId), AnimeTracker.getStats(db, userId), AnimeTracker.getFavorites(db, userId), Follow.followerCount(db, userId), Follow.followingCount(db, userId)]);
+  return c.json({ success: true, user: { id: user.id, username: user.username, email: user.email, avatarUrl: user.avatar_url, bio: user.bio, role: user.role, hasGoogle: !!user.google_id, hasDiscord: !!user.discord_id, hasPassword: !!user.password_hash }, stats, badges: badges.map((b) => ({ id: b.id, name: b.name, description: b.description, iconText: b.icon_text, imageUrl: b.image_url, color: b.color })), favorites: favorites.map((f: any) => ({ animeId: f.anime_id, title: f.anime_title, image: f.anime_image })), followerCount, followingCount });
+});
+
+mobileContentRoutes.get('/api/mobile/user/:username', async (c) => {
+  const { db, auth, session } = await buildCtx(c); const username = c.req.param('username').trim(); if (!username) return c.json({ success: false, message: 'Invalid username.' }, 400);
+  const profileUser = await db.fetchOne<any>('SELECT id, username, avatar_url, bio, role, created_at, privacy_hide_followers, privacy_hide_following, privacy_hide_favorites FROM users WHERE username = ? AND is_active = 1', [username]);
+  if (!profileUser) return c.json({ success: false, message: 'User not found.' }, 404);
+  const { Badge } = await import('../lib/badges'); const { AnimeTracker } = await import('../lib/tracker'); const { Follow } = await import('../lib/follow'); const currentUserId = auth.check() ? session.user_id! : null; const isOwn = currentUserId === profileUser.id;
+  const [badges, stats, followerCount, followingCount, isFollowing] = await Promise.all([Badge.getForUser(db, profileUser.id), AnimeTracker.getStats(db, profileUser.id), Follow.followerCount(db, profileUser.id), Follow.followingCount(db, profileUser.id), currentUserId && !isOwn ? Follow.isFollowing(db, currentUserId, profileUser.id) : Promise.resolve(false)]);
+  const canViewFavorites = isOwn || !profileUser.privacy_hide_favorites; const favorites = canViewFavorites ? await AnimeTracker.getFavorites(db, profileUser.id) : [];
+  return c.json({ success: true, user: { id: profileUser.id, username: profileUser.username, avatarUrl: profileUser.avatar_url, bio: profileUser.bio, role: profileUser.role, joinedAt: profileUser.created_at }, stats, badges: badges.map((b) => ({ id: b.id, name: b.name, description: b.description, iconText: b.icon_text, imageUrl: b.image_url, color: b.color })), favorites: canViewFavorites ? favorites.map((f: any) => ({ animeId: f.anime_id, title: f.anime_title, image: f.anime_image })) : null, followerCount, followingCount, isOwn, isFollowing, canViewFollowers: isOwn || !profileUser.privacy_hide_followers, canViewFollowing: isOwn || !profileUser.privacy_hide_following });
+});
+
+mobileContentRoutes.get('/api/mobile/home', async (c) => {
+  const { db, auth, mal } = await buildCtx(c); const [seasonal, topAnime, upcoming] = await Promise.all([mal.getAniListSeasonNow(), mal.getTopAnime('bypopularity', 1), mal.getSeasonUpcoming()]);
+  const toCard = (a: any) => ({ id: a.mal_id, title: a.title_english && a.title_english !== a.title ? a.title_english : a.title, image: a.images?.jpg?.large_image_url ?? a.images?.jpg?.image_url ?? '', score: a.score ?? null, type: a.type ?? '', episodes: a.episodes ?? 0 });
+  let watchNowList: any[] = []; try { const rows = await db.fetchAll<{ anime_id: number }>('SELECT DISTINCT anime_id FROM episode_videos WHERE is_active = 1 ORDER BY updated_at DESC LIMIT 12'); const results = await Promise.all(rows.map((r) => mal.getAnime(r.anime_id, true))); watchNowList = results.map((r) => r.data).filter(Boolean).map(toCard); } catch { watchNowList = []; }
+  const currentUser = auth.check() ? await auth.getCurrentUser() : null; let continueWatching: any[] = [];
+  if (currentUser) { try { const rows = await db.fetchAll<any>('SELECT anime_id, anime_title, anime_image, episode_num, ep_title, ep_thumb, watched_at, watch_time, episode_duration FROM watch_history WHERE user_id = ? ORDER BY watched_at DESC LIMIT 8', [currentUser.id]); continueWatching = rows.map((r) => ({ animeId: r.anime_id, title: r.anime_title, image: r.anime_image, episodeNum: r.episode_num, epTitle: r.ep_title, epThumb: r.ep_thumb, watchTime: r.watch_time, episodeDuration: r.episode_duration })); } catch { continueWatching = []; } }
+  return c.json({ success: true, seasonal: (seasonal.data ?? []).slice(0, 12).map(toCard), top: (topAnime.data ?? []).slice(0, 12).map(toCard), upcoming: (upcoming.data ?? []).slice(0, 8).map(toCard), watchNow: watchNowList, continueWatching });
+});
+
+mobileContentRoutes.get('/api/mobile/watch-now', async (c) => {
+  const { db, mal } = await buildCtx(c); const perPage = 24; const page = Math.max(1, parseInt(c.req.query('page') ?? '1', 10) || 1); const offset = (page - 1) * perPage;
+  const total = await db.count('SELECT COUNT(DISTINCT anime_id) as cnt FROM episode_videos WHERE is_active = 1'); const rows = await db.fetchAll<{ anime_id: number }>('SELECT DISTINCT anime_id FROM episode_videos WHERE is_active = 1 ORDER BY updated_at DESC LIMIT ? OFFSET ?', [perPage, offset]); const results = await Promise.all(rows.map((r) => mal.getAnime(r.anime_id, true))); const animeList = results.map((r) => r.data).filter(Boolean) as any[];
+  return c.json({ success: true, data: animeList.map((a) => ({ id: a.mal_id, title: a.title_english && a.title_english !== a.title ? a.title_english : a.title, image: a.images?.jpg?.large_image_url ?? '', score: a.score ?? null, type: a.type ?? '', episodes: a.episodes ?? 0 })), page, totalPages: total > 0 ? Math.ceil(total / perPage) : 1 });
+});
+
+mobileContentRoutes.get('/api/mobile/history', async (c) => {
+  const { db, auth, session } = await buildCtx(c); if (!auth.check()) return c.json({ success: false, message: 'Not logged in.' }, 401); const limit = 24; const page = Math.max(1, parseInt(c.req.query('page') ?? '1', 10) || 1); const offset = (page - 1) * limit; const userId = session.user_id!;
+  const total = await db.count('SELECT COUNT(*) as cnt FROM watch_history WHERE user_id = ?', [userId]); const rows = await db.fetchAll<any>('SELECT anime_id, anime_title, anime_image, episode_num, ep_title, ep_thumb, watched_at, watch_time, episode_duration FROM watch_history WHERE user_id = ? ORDER BY watched_at DESC LIMIT ? OFFSET ?', [userId, limit, offset]);
+  return c.json({ success: true, data: rows.map((r) => ({ animeId: r.anime_id, title: r.anime_title, image: r.anime_image, episodeNum: r.episode_num, epTitle: r.ep_title, epThumb: r.ep_thumb, watchedAt: r.watched_at, watchTime: r.watch_time, episodeDuration: r.episode_duration })), page, totalPages: total ? Math.ceil(total / limit) : 1 });
+});
+
+mobileContentRoutes.get('/api/mobile/announcements', async (c) => {
+  const { db } = await buildCtx(c); const rows = await db.fetchAll<any>('SELECT * FROM announcements WHERE is_active=1 ORDER BY created_at DESC'); return c.json({ success: true, data: rows.map((a) => ({ id: a.id, title: a.title, content: a.content, imageUrl: a.image_url ?? null, createdAt: a.created_at })) });
+});
+
+mobileContentRoutes.get('/api/mobile/character/:id', async (c) => {
+  const { mal } = await buildCtx(c); const charId = parseInt(c.req.param('id'), 10) || 0; if (!charId) return c.json({ success: false, message: 'Invalid character id.' }, 400);
+  const { character: charData, animeography: charAnimeData, voices: charVoicesData } = await mal.getCharacterFull(charId); const char = charData?.data; if (!char) return c.json({ success: false, message: 'Character not found.' }, 404);
+  return c.json({ success: true, character: { id: charId, name: char.name ?? 'Unknown Character', nameKanji: char.name_kanji ?? null, nicknames: char.nicknames ?? [], about: char.about ?? null, favorites: char.favorites ?? 0, image: char.images?.jpg?.image_url ?? '' }, animeography: (charAnimeData?.data ?? []).slice(0, 12).map((a: any) => ({ animeId: a.anime?.mal_id, title: a.anime?.title, image: a.anime?.images?.jpg?.image_url, role: a.role })), voices: (charVoicesData?.data ?? []).map((v: any) => ({ name: v.person?.name, image: v.person?.image_url, language: v.language })) });
+});
+
+mobileContentRoutes.get('/api/mobile/anime/:id/characters', async (c) => {
+  const { mal } = await buildCtx(c); const id = parseInt(c.req.param('id'), 10) || 0; if (!id) return c.json({ success: false, message: 'Invalid anime id.' }, 400); const result = await mal.getAnimeCharacters(id); const data = (result?.data ?? []).slice(0, 20).map((r: any) => ({ id: r.character?.mal_id, name: r.character?.name, image: r.character?.images?.jpg?.image_url, role: r.role })); return c.json({ success: true, data });
+});
+
+export { mobileContentRoutes as default };


### PR DESCRIPTION
Integrates the separate AniVault mobile app backend into the main AniVault Worker: bearer-token sessions, mobile auth/content endpoints, Expo push-token registration/delivery, and the D1 push_tokens migration.